### PR TITLE
Update lib/__express.js

### DIFF
--- a/lib/__express.js
+++ b/lib/__express.js
@@ -7,7 +7,11 @@ module.exports = function(path, options, fn) {
   var partials = [''];  // empty string at index 0
   for (var p in options.partials) {
     partials.push(p);
-    templates.push(join(options.settings.views, options.partials[p]));
+    if (options.partials[p].charAt(0) === '/') {
+      templates.push(options.partials[p]);
+    } else {
+      templates.push(join(options.settings.views, options.partials[p]));
+    }
   }
   var pending = templates.length;
 


### PR DESCRIPTION
Leading slash for absolute partial path

If the path to a partial begins with a leading slash, it is treated
as if it were an absolute path to that view file. If it doesn't have
a leading slash, it is treated like a relative path as usual.

Wrote this to fix bug #15
