### PR TITLE
Do not compile partials when already compiled

### DIFF
--- a/lib/__express.js
+++ b/lib/__express.js
@@ -6,8 +6,10 @@ module.exports = function(path, options, fn) {
   var templates = [path];
   var partials = [''];  // empty string at index 0
   for (var p in options.partials) {
-    partials.push(p);
-    templates.push(resolve(options.settings.views, options.partials[p]));
+    if(typeof options.partials[p] !== "function") {
+        partials.push(p);
+        templates.push(resolve(options.settings.views, options.partials[p]));
+      }
   }
   var pending = templates.length;
 


### PR DESCRIPTION
When a page, with partials, was loaded twice, a weird bug appeared: **"arguments to path.resolve must be strings"**.
In `__express.js:10`, **all** the partials' paths were added to `templates`, to be compiled (on line 30), even if they were already compiled and stored in the cache.

I fixed it with a small `if` statement inside the for loop. Now it works correctly, at least for me (I didn't test it thoroughly)

PS: can you publish as fast as possible to npm? I quite need it for a project of mine :)
